### PR TITLE
fix route display bug and auto-select first route on load

### DIFF
--- a/_site/melville-in-london/ui/js/script.js
+++ b/_site/melville-in-london/ui/js/script.js
@@ -149,7 +149,7 @@ $(document).ready(function() {
     L.geoJson(data.itinerary_paths.map(function(path, index) {
       var geo = path.geo_object;
       geo._index = index;
-      geo._color = colors[index];
+      geo._color = colors[index % colors.length];
       geo._unit = path.group;
       geo._text = path.text;
       geo._primacy = path.primacy;
@@ -239,6 +239,6 @@ $(document).ready(function() {
       tempShownLayer = null;
     }
 
-    $(".day-nav-header").first().click();
+    $(".day .day-nav-header").first().click();
   });
 });

--- a/melville-in-london/ui/js/script.js
+++ b/melville-in-london/ui/js/script.js
@@ -149,7 +149,7 @@ $(document).ready(function() {
     L.geoJson(data.itinerary_paths.map(function(path, index) {
       var geo = path.geo_object;
       geo._index = index;
-      geo._color = colors[index];
+      geo._color = colors[index % colors.length];
       geo._unit = path.group;
       geo._text = path.text;
       geo._primacy = path.primacy;
@@ -239,6 +239,6 @@ $(document).ready(function() {
       tempShownLayer = null;
     }
 
-    $(".day-nav-header").first().click();
+    $(".day .day-nav-header").first().click();
   });
 });


### PR DESCRIPTION
This PR makes minor changes to the JS loader for Itineraries from MelCat, currently used in the Melville in London page. It fixes a bug where some routes would not display if there were more routes than the length of the predefined colors array, and also adds a trigger to automatically select the first day's routes for display upon completion of data load.