### PR TITLE
side-scrolling control-indicators for day nav; display routes in data table

### DIFF
--- a/_site/melville-in-london/index.html
+++ b/_site/melville-in-london/index.html
@@ -71,6 +71,8 @@
       <h2>Routes Taken</h2>
       <div id="path-nav-table-holder"><table><tbody><tr id="path-nav-row">
         <td class='row-legend'><h3 class='day-nav-header'>Day</h3><ul><li>Primary route</li><li>Alternate routes</li></ul></td>
+        <td class="row-scroll row-scroll-left"><br /><a href="#">&lsaquo;</a></td>
+        <td class="row-scroll row-scroll-right"><br /><a href="#">&rsaquo;</a></td>
       </tr></tbody></table></div>
     </div>
     <div class="itinerary">

--- a/_site/ui/css/styles.css
+++ b/_site/ui/css/styles.css
@@ -452,6 +452,10 @@ span.code {
   margin-bottom: 40px;
 }
 
+#data-container table td {
+  max-width: 400px;
+}
+
 div#path-nav-table-holder {
   float: none;
 
@@ -475,4 +479,29 @@ div#path-nav-table-holder {
   position: absolute;
   background-color: white;
   left: 90px;
+}
+
+#path-nav-row td.row-scroll {
+  position: absolute;
+  display: none;
+}
+
+#path-nav-row td.row-scroll a {
+  text-decoration: none;
+  font-family: 'IM Fell DW Pica SC', serif;
+  font-size: 42px;
+  font-weight: lighter;
+  color: #AAA;
+}
+
+#path-nav-row td.row-scroll a:hover {
+  color: #3d3934;
+}
+
+#path-nav-row td.row-scroll-left {
+  left: 225px;
+}
+
+#path-nav-row td.row-scroll-right {
+  right: 40px;
 }

--- a/melville-in-london/index.html
+++ b/melville-in-london/index.html
@@ -18,6 +18,8 @@ page_title: Melville in London
       <h2>Routes Taken</h2>
       <div id="path-nav-table-holder"><table><tbody><tr id="path-nav-row">
         <td class='row-legend'><h3 class='day-nav-header'>Day</h3><ul><li>Primary route</li><li>Alternate routes</li></ul></td>
+        <td class="row-scroll row-scroll-left"><br /><a href="#">&lsaquo;</a></td>
+        <td class="row-scroll row-scroll-right"><br /><a href="#">&rsaquo;</a></td>
       </tr></tbody></table></div>
     </div>
     <div class="itinerary">

--- a/ui/css/styles.css
+++ b/ui/css/styles.css
@@ -452,6 +452,10 @@ span.code {
   margin-bottom: 40px;
 }
 
+#data-container table td {
+  max-width: 400px;
+}
+
 div#path-nav-table-holder {
   float: none;
 
@@ -475,4 +479,29 @@ div#path-nav-table-holder {
   position: absolute;
   background-color: white;
   left: 90px;
+}
+
+#path-nav-row td.row-scroll {
+  position: absolute;
+  display: none;
+}
+
+#path-nav-row td.row-scroll a {
+  text-decoration: none;
+  font-family: 'IM Fell DW Pica SC', serif;
+  font-size: 42px;
+  font-weight: lighter;
+  color: #AAA;
+}
+
+#path-nav-row td.row-scroll a:hover {
+  color: #3d3934;
+}
+
+#path-nav-row td.row-scroll-left {
+  left: 225px;
+}
+
+#path-nav-row td.row-scroll-right {
+  right: 40px;
 }


### PR DESCRIPTION
This PR adds two features:
- Left and right arrows to indicate that the row of day/route checkboxes can be scrolled horizontally to access the full set; clicking these arrows will also increment the scroll position in case horizontal scrolling is not available/intuitive.
- Routes now display as rows in the data table, with links to show them on the map. If a route has a route narrative, this will be shown in its row's 'WK Editorial Note' field as well as in the popup for its map element.